### PR TITLE
Windows seperator fix

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ exports.contains = function contains(mainPath, subPath) {
   mainPath = resolvePath(mainPath);
   subPath = resolvePath(subPath);
   return subPath.indexOf(mainPath) === 0
-    && subPath.slice(mainPath.length)[0] === '/';
+    && subPath.slice(mainPath.length)[0] === sep;
 };
 
 exports.within = function within(subPath, mainPath) {


### PR DESCRIPTION
Super small fix: use `path.sep` instead of hardcoded `/`

PS: Thanks for the plugin!!! :-)
